### PR TITLE
Add filter for group name

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ usage: mvnchk [<path>] [-d <arg>] [-h] [-i] [--ignore-inherited] [-s] [-v]
                          version
     --ignore-inherited   Ignore build file artifacts with an inherited
                          version
+ -f,--filter             RegEx to filter out build file artifacts 
+                         with a non mathing group name
  -s,--short              Only show build files with at least one artifact
                          update
  -v,--version            Display version information
@@ -109,6 +111,16 @@ com.google.guava:guava:*-android
 
 # Ignore artifact update versions using the "any single character" wildcard
 com.google.guava:guava:30.?-android
+```
+
+## Filter
+_MvnCheck_ allows to ignore artifacts based on a regular expression pattern for the group name.
+This allows to search only for artifact update with the given group pattern.
+
+Here is an example of how to only search for artifact 
+with the group name suffix `com.github.alexisjehan`:
+```
+- filter com.github.alexisjehan.*
 ```
 
 ## Compatibility matrix

--- a/src/main/java/com/github/alexisjehan/mvncheck/core/Service.java
+++ b/src/main/java/com/github/alexisjehan/mvncheck/core/Service.java
@@ -45,6 +45,7 @@ import com.github.alexisjehan.mvncheck.core.component.filter.version.factory.Ver
 import com.github.alexisjehan.mvncheck.core.component.session.MavenSession;
 import com.github.alexisjehan.mvncheck.core.util.SystemUtils;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -54,6 +55,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -62,236 +64,271 @@ import java.util.stream.Collectors;
  */
 public final class Service {
 
-	/**
-	 * <p>Ignore file name.</p>
-	 * @since 1.0.0
-	 */
-	private static final String IGNORE_FILE_NAME = ".mvnchk-ignore";
+    /**
+     * <p>Ignore file name.</p>
+     * @since 1.0.0
+     */
+    private static final String IGNORE_FILE_NAME = ".mvnchk-ignore";
 
-	/**
-	 * <p>{@link Set} of build resolvers.</p>
-	 * @since 1.0.0
-	 */
-	private final Set<BuildResolver> buildResolvers;
+    /**
+     * <p>{@link Set} of build resolvers.</p>
+     *
+     * @since 1.0.0
+     */
+    private final Set<BuildResolver> buildResolvers;
 
-	/**
-	 * <p>Artifact available versions resolver.</p>
-	 * @since 1.0.0
-	 */
-	private final ArtifactAvailableVersionsResolver artifactAvailableVersionsResolver;
+    /**
+     * <p>Artifact available versions resolver.</p>
+     *
+     * @since 1.0.0
+     */
+    private final ArtifactAvailableVersionsResolver artifactAvailableVersionsResolver;
 
-	/**
-	 * <p>Version filter factory.</p>
-	 * @since 1.0.0
-	 */
-	private final VersionFilterFactory versionFilterFactory = new CompositeVersionFilterFactory(
-			new QualifierVersionFilterFactory(),
-			new ReleaseVersionFilterFactory()
-	);
+    /**
+     * <p>Version filter factory.</p>
+     *
+     * @since 1.0.0
+     */
+    private final VersionFilterFactory versionFilterFactory = new CompositeVersionFilterFactory(
+            new QualifierVersionFilterFactory(),
+            new ReleaseVersionFilterFactory()
+    );
 
-	/**
-	 * <p>User artifact filter.</p>
-	 * @since 1.0.0
-	 */
-	private final ArtifactFilter userArtifactFilter;
+    /**
+     * <p>User artifact filter.</p>
+     * @since 1.0.0
+     */
+    private final ArtifactFilter userArtifactFilter;
 
-	/**
-	 * <p>Constructor with a <i>Maven</i> session.</p>
-	 * @param mavenSession a <i>Maven</i> session
-	 * @throws IOException might occur with input/output operations
-	 * @throws NullPointerException if the <i>Maven</i> session is {@code null}
-	 * @since 1.0.0
-	 */
-	public Service(final MavenSession mavenSession) throws IOException {
-		this(
-				Set.of(
-						new MavenBuildResolver(Ensure.notNull("mavenSession", mavenSession)),
-						new GradleBuildResolver()
-				),
-				new MavenArtifactAvailableVersionsResolver(mavenSession)
-		);
-	}
+    /**
+     * <p>Constructor with a <i>Maven</i> session.</p>
+     *
+     * @param mavenSession a <i>Maven</i> session
+     * @throws IOException          might occur with input/output operations
+     * @throws NullPointerException if the <i>Maven</i> session is {@code null}
+     * @since 1.0.0
+     */
+    public Service(final MavenSession mavenSession) throws IOException {
+        this(
+                Set.of(
+                        new MavenBuildResolver(Ensure.notNull("mavenSession", mavenSession)),
+                        new GradleBuildResolver()
+                ),
+                new MavenArtifactAvailableVersionsResolver(mavenSession)
+        );
+    }
 
-	/**
-	 * <p>Constructor with a {@link Set} of build resolvers and an artifact available versions resolver.</p>
-	 * @param buildResolvers a {@link Set} of build resolvers
-	 * @param artifactAvailableVersionsResolver an artifact available versions resolver
-	 * @throws IOException might occur with input/output operations
-	 * @throws NullPointerException if the {@link Set} of build resolvers, any of them or the artifact available
-	 *         versions resolver is {@code null}
-	 * @since 1.0.0
-	 */
-	Service(
-			final Set<BuildResolver> buildResolvers,
-			final ArtifactAvailableVersionsResolver artifactAvailableVersionsResolver
-	) throws IOException {
-		Ensure.notNullAndNotNullElements("buildResolvers", buildResolvers);
-		Ensure.notNull("artifactAvailableVersionsResolver", artifactAvailableVersionsResolver);
-		this.buildResolvers = Set.copyOf(buildResolvers);
-		this.artifactAvailableVersionsResolver = artifactAvailableVersionsResolver;
-		userArtifactFilter = createUserArtifactFilter();
-	}
+    /**
+     * <p>Constructor with a {@link Set} of build resolvers and an artifact available versions resolver.</p>
+     *
+     * @param buildResolvers                    a {@link Set} of build resolvers
+     * @param artifactAvailableVersionsResolver an artifact available versions resolver
+     * @throws IOException          might occur with input/output operations
+     * @throws NullPointerException if the {@link Set} of build resolvers, any of them or the artifact available
+     *                              versions resolver is {@code null}
+     * @since 1.0.0
+     */
+    Service(
+            final Set<BuildResolver> buildResolvers,
+            final ArtifactAvailableVersionsResolver artifactAvailableVersionsResolver
+    ) throws IOException {
+        Ensure.notNullAndNotNullElements("buildResolvers", buildResolvers);
+        Ensure.notNull("artifactAvailableVersionsResolver", artifactAvailableVersionsResolver);
+        this.buildResolvers = Set.copyOf(buildResolvers);
+        this.artifactAvailableVersionsResolver = artifactAvailableVersionsResolver;
+        userArtifactFilter = createUserArtifactFilter();
+    }
 
-	/**
-	 * <p>Find a {@link List} of build files in the given path, recursively.</p>
-	 * @param path a path
-	 * @return the {@link List} of build files
-	 * @throws IOException might occur with input/output operations
-	 * @throws NullPointerException if the path is {@code null}
-	 * @throws IllegalArgumentException if the path does not exist
-	 * @deprecated since 1.1.0, use {@link #findBuildFiles(Path, int)} instead
-	 * @since 1.0.0
-	 */
-	@Deprecated(since = "1.1.0")
-	public List<BuildFile> findBuildFiles(final Path path) throws IOException {
-		return findBuildFiles(path, Integer.MAX_VALUE);
-	}
+    /**
+     * <p>Find a {@link List} of build files in the given path, recursively.</p>
+     *
+     * @param path a path
+     * @return the {@link List} of build files
+     * @throws IOException              might occur with input/output operations
+     * @throws NullPointerException     if the path is {@code null}
+     * @throws IllegalArgumentException if the path does not exist
+     * @since 1.0.0
+     * @deprecated since 1.1.0, use {@link #findBuildFiles(Path, int)} instead
+     */
+    @Deprecated(since = "1.1.0")
+    public List<BuildFile> findBuildFiles(final Path path) throws IOException {
+        return findBuildFiles(path, Integer.MAX_VALUE);
+    }
 
-	/**
-	 * <p>Find a {@link List} of build files in the given path, recursively.</p>
-	 * @param path a path
-	 * @param maxDepth a maximum depth
-	 * @return the {@link List} of build files
-	 * @throws IOException might occur with input/output operations
-	 * @throws NullPointerException if the path is {@code null}
-	 * @throws IllegalArgumentException if the path does not exist or if the maximum depth is lower than {@code 0}
-	 * @since 1.1.0
-	 */
-	public List<BuildFile> findBuildFiles(final Path path, final int maxDepth) throws IOException {
-		Ensure.notNullAndExists("path", path);
-		Ensure.greaterThanOrEqualTo("maxDepth", maxDepth, 0);
-		try (var stream = Files.walk(path, Integer.MAX_VALUE > maxDepth ? maxDepth + 1 : Integer.MAX_VALUE)) {
-			return stream
-					.filter(Files::isRegularFile)
-					.map(file -> {
-						final var fileName = file.getFileName().toString();
-						return BuildFileType.optionalValueOf(fileName).map(type -> new BuildFile(type, file));
-					})
-					.flatMap(Optional::stream)
-					.sorted(
-							Comparator
-									.<BuildFile, String>comparing(
-											buildFile -> buildFile.getFile().getParent().toString(),
-											Comparators.NUMBER_AWARE
-									)
-									.thenComparing(
-											buildFile -> buildFile.getFile().getFileName().toString(),
-											Comparators.NUMBER_AWARE
-									)
-					)
-					.collect(Collectors.toUnmodifiableList());
-		}
-	}
+    /**
+     * <p>Find a {@link List} of build files in the given path, recursively.</p>
+     *
+     * @param path     a path
+     * @param maxDepth a maximum depth
+     * @return the {@link List} of build files
+     * @throws IOException              might occur with input/output operations
+     * @throws NullPointerException     if the path is {@code null}
+     * @throws IllegalArgumentException if the path does not exist or if the maximum depth is lower than {@code 0}
+     * @since 1.1.0
+     */
+    public List<BuildFile> findBuildFiles(final Path path, final int maxDepth) throws IOException {
+        Ensure.notNullAndExists("path", path);
+        Ensure.greaterThanOrEqualTo("maxDepth", maxDepth, 0);
+        try (var stream = Files.walk(path, Integer.MAX_VALUE > maxDepth ? maxDepth + 1 : Integer.MAX_VALUE)) {
+            return stream
+                    .filter(Files::isRegularFile)
+                    .map(file -> {
+                        final var fileName = file.getFileName().toString();
+                        return BuildFileType.optionalValueOf(fileName).map(type -> new BuildFile(type, file));
+                    })
+                    .flatMap(Optional::stream)
+                    .sorted(
+                            Comparator
+                                    .<BuildFile, String>comparing(
+                                            buildFile -> buildFile.getFile().getParent().toString(),
+                                            Comparators.NUMBER_AWARE
+                                    )
+                                    .thenComparing(
+                                            buildFile -> buildFile.getFile().getFileName().toString(),
+                                            Comparators.NUMBER_AWARE
+                                    )
+                    )
+                    .collect(Collectors.toUnmodifiableList());
+        }
+    }
 
-	/**
-	 * <p>Find the build for the given build file.</p>
-	 * @param buildFile a build file
-	 * @return the build
-	 * @throws NullPointerException if the build file is {@code null}
-	 * @since 1.0.0
-	 */
-	public Build findBuild(final BuildFile buildFile) {
-		Ensure.notNull("buildFile", buildFile);
-		return buildResolvers.stream()
-				.filter(buildResolver -> buildResolver.getFileTypes().contains(buildFile.getType()))
-				.findAny()
-				.map(buildResolver -> buildResolver.resolve(buildFile))
-				.orElseThrow();
-	}
+    /**
+     * <p>Find the build for the given build file.</p>
+     *
+     * @param buildFile a build file
+     * @return the build
+     * @throws NullPointerException if the build file is {@code null}
+     * @since 1.0.0
+     */
+    public Build findBuild(final BuildFile buildFile) {
+        Ensure.notNull("buildFile", buildFile);
+        return buildResolvers.stream()
+                .filter(buildResolver -> buildResolver.getFileTypes().contains(buildFile.getType()))
+                .findAny()
+                .map(buildResolver -> buildResolver.resolve(buildFile))
+                .orElseThrow();
+    }
 
-	/**
-	 * <p>Find a {@link List} of artifact update versions for the given build.</p>
-	 * @param build a build
-	 * @param ignoreSnapshots {@code true} if build file artifacts with a snapshot version should be ignored
-	 * @return the {@link List} of artifact update versions
-	 * @throws IOException might occur with input/output operations
-	 * @throws NullPointerException if the build is {@code null}
-	 * @deprecated since 1.5.0, use {@link #findArtifactUpdateVersions(Build, boolean, boolean)} instead
-	 * @since 1.0.0
-	 */
-	@Deprecated(since = "1.5.0")
-	public List<ArtifactUpdateVersion> findArtifactUpdateVersions(
-			final Build build,
-			final boolean ignoreSnapshots
-	) throws IOException {
-		return findArtifactUpdateVersions(build, false, ignoreSnapshots);
-	}
+    /**
+     * <p>Find a {@link List} of artifact update versions for the given build.</p>
+     *
+     * @param build           a build
+     * @param ignoreSnapshots {@code true} if build file artifacts with a snapshot version should be ignored
+     * @return the {@link List} of artifact update versions
+     * @throws IOException          might occur with input/output operations
+     * @throws NullPointerException if the build is {@code null}
+     * @since 1.0.0
+     * @deprecated since 1.5.0, use {@link #findArtifactUpdateVersions(Build, boolean, boolean)} instead
+     */
+    @Deprecated(since = "1.5.0")
+    public List<ArtifactUpdateVersion> findArtifactUpdateVersions(
+            final Build build,
+            final boolean ignoreSnapshots
+    ) throws IOException {
+        return findArtifactUpdateVersions(build, false, ignoreSnapshots);
+    }
 
-	/**
-	 * <p>Find a {@link List} of artifact update versions for the given build.</p>
-	 * @param build a build
-	 * @param ignoreInherited {@code true} if build file artifacts with an inherited version should be ignored
-	 * @param ignoreSnapshots {@code true} if build file artifacts with a snapshot version should be ignored
-	 * @return the {@link List} of artifact update versions
-	 * @throws IOException might occur with input/output operations
-	 * @throws NullPointerException if the build is {@code null}
-	 * @since 1.5.0
-	 */
-	public List<ArtifactUpdateVersion> findArtifactUpdateVersions(
-			final Build build,
-			final boolean ignoreInherited,
-			final boolean ignoreSnapshots
-	) throws IOException {
-		Ensure.notNull("build", build);
-		final var artifactFilter = new CompositeArtifactFilter(
-				userArtifactFilter,
-				createBuildArtifactFilter(build.getFile())
-		);
-		return build.getArtifacts()
-				.parallelStream()
-				.filter(artifactFilter::accept)
-				.filter(artifact -> !ignoreInherited || !artifact.isVersionInherited())
-				.filter(
-						artifact -> artifact.getOptionalVersion()
-								.filter(version -> !ignoreSnapshots || !VersionFilter.SNAPSHOT.accept(version))
-								.isPresent()
-				)
-				.map(artifact -> artifactAvailableVersionsResolver.resolve(artifact, build.getRepositories()))
-				.map(artifactAvailableVersions -> {
-					final var artifact = artifactAvailableVersions.getArtifact();
-					final var artifactVersion = artifact.getOptionalVersion().orElseThrow();
-					final var availableVersions = new ArrayList<>(artifactAvailableVersions.getAvailableVersions());
-					if (availableVersions.isEmpty()) {
-						return Optional.<ArtifactUpdateVersion>empty();
-					}
-					Collections.reverse(availableVersions);
-					return availableVersions.stream()
-							.filter(updateVersion -> artifactFilter.accept(artifact, updateVersion))
-							.filter(versionFilterFactory.create(artifactVersion)::accept)
-							.findAny()
-							.filter(updateVersion -> !artifactVersion.equals(updateVersion))
-							.map(updateVersion -> new ArtifactUpdateVersion(artifact, updateVersion));
-				})
-				.flatMap(Optional::stream)
-				.collect(Collectors.toUnmodifiableList());
-	}
+    /**
+     * <p>Find a {@link List} of artifact update versions for the given build.</p>
+     *
+     * @param build           a build
+     * @param ignoreInherited {@code true} if build file artifacts with an inherited version should be ignored
+     * @param ignoreSnapshots {@code true} if build file artifacts with a snapshot version should be ignored
+     * @return the {@link List} of artifact update versions
+     * @throws IOException          might occur with input/output operations
+     * @throws NullPointerException if the build is {@code null}
+     * @since 1.5.0
+     */
+    public List<ArtifactUpdateVersion> findArtifactUpdateVersions(
+            final Build build,
+            final boolean ignoreInherited,
+            final boolean ignoreSnapshots
+    ) throws IOException {
+        return findArtifactUpdateVersions(build, ignoreInherited, ignoreSnapshots);
+    }
+    
+    /**
+     * <p>Find a {@link List} of artifact update versions for the given build.</p>
+     *
+     * @param build           a build
+     * @param ignoreInherited {@code true} if build file artifacts with an inherited version should be ignored
+     * @param ignoreSnapshots {@code true} if build file artifacts with a snapshot version should be ignored
+     * @param groupFilter     build file artifacts with a not matching {@code groupId} should be ignored. 
+     *                        Will be ignored if {@code null}.
+     * @return the {@link List} of artifact update versions
+     * @throws IOException          might occur with input/output operations
+     * @throws NullPointerException if the build is {@code null}
+     * @since 1.7.0
+     */
+    public List<ArtifactUpdateVersion> findArtifactUpdateVersions(
+            final Build build,
+            final boolean ignoreInherited,
+            final boolean ignoreSnapshots,
+            @Nullable final Pattern groupFilter
+    ) throws IOException {
+        Ensure.notNull("build", build);
+        final var artifactFilter = new CompositeArtifactFilter(
+                userArtifactFilter,
+                createBuildArtifactFilter(build.getFile())
+        );
+        return build.getArtifacts()
+                .parallelStream()
+                .filter(artifact -> groupFilter == null || groupFilter.asMatchPredicate().test(artifact.getIdentifier().getGroupId()))
+                .filter(artifactFilter::accept)
+                .filter(artifact -> !ignoreInherited || !artifact.isVersionInherited())
+                .filter(
+                        artifact -> artifact.getOptionalVersion()
+                                .filter(version -> !ignoreSnapshots || !VersionFilter.SNAPSHOT.accept(version))
+                                .isPresent()
+                )
+                .map(artifact -> artifactAvailableVersionsResolver.resolve(artifact, build.getRepositories()))
+                .map(artifactAvailableVersions -> {
+                    final var artifact = artifactAvailableVersions.getArtifact();
+                    final var artifactVersion = artifact.getOptionalVersion().orElseThrow();
+                    final var availableVersions = new ArrayList<>(artifactAvailableVersions.getAvailableVersions());
+                    if (availableVersions.isEmpty()) {
+                        return Optional.<ArtifactUpdateVersion>empty();
+                    }
+                    Collections.reverse(availableVersions);
+                    return availableVersions.stream()
+                            .filter(updateVersion -> artifactFilter.accept(artifact, updateVersion))
+                            .filter(versionFilterFactory.create(artifactVersion)::accept)
+                            .findAny()
+                            .filter(updateVersion -> !artifactVersion.equals(updateVersion))
+                            .map(updateVersion -> new ArtifactUpdateVersion(artifact, updateVersion));
+                })
+                .flatMap(Optional::stream)
+                .collect(Collectors.toUnmodifiableList());
+    }
 
-	/**
-	 * <p>Create the user artifact filter.</p>
-	 * @return the user artifact filter
-	 * @throws IOException might occur with input/output operations
-	 * @since 1.0.0
-	 */
-	static ArtifactFilter createUserArtifactFilter() throws IOException {
-		final var userIgnoreFile = SystemUtils.getUserHomeDirectory().resolve(IGNORE_FILE_NAME);
-		return Files.isRegularFile(userIgnoreFile)
-				? ArtifactFilterParser.parse(userIgnoreFile)
-				: ArtifactFilter.NONE;
-	}
+    /**
+     * <p>Create the user artifact filter.</p>
+     *
+     * @return the user artifact filter
+     * @throws IOException might occur with input/output operations
+     * @since 1.0.0
+     */
+    static ArtifactFilter createUserArtifactFilter() throws IOException {
+        final var userIgnoreFile = SystemUtils.getUserHomeDirectory().resolve(IGNORE_FILE_NAME);
+        return Files.isRegularFile(userIgnoreFile)
+                ? ArtifactFilterParser.parse(userIgnoreFile)
+                : ArtifactFilter.NONE;
+    }
 
-	/**
-	 * <p>Create the build artifact filter for the given build file.</p>
-	 * @param buildFile a build file
-	 * @return the build artifact filter
-	 * @throws IOException might occur with input/output operations
-	 * @throws NullPointerException if the build file is {@code null}
-	 * @since 1.0.0
-	 */
-	static ArtifactFilter createBuildArtifactFilter(final BuildFile buildFile) throws IOException {
-		Ensure.notNull("buildFile", buildFile);
-		final var buildIgnoreFile = buildFile.getFile().getParent().resolve(IGNORE_FILE_NAME);
-		return Files.isRegularFile(buildIgnoreFile)
-				? ArtifactFilterParser.parse(buildIgnoreFile)
-				: ArtifactFilter.NONE;
-	}
+    /**
+     * <p>Create the build artifact filter for the given build file.</p>
+     *
+     * @param buildFile a build file
+     * @return the build artifact filter
+     * @throws IOException          might occur with input/output operations
+     * @throws NullPointerException if the build file is {@code null}
+     * @since 1.0.0
+     */
+    static ArtifactFilter createBuildArtifactFilter(final BuildFile buildFile) throws IOException {
+        Ensure.notNull("buildFile", buildFile);
+        final var buildIgnoreFile = buildFile.getFile().getParent().resolve(IGNORE_FILE_NAME);
+        return Files.isRegularFile(buildIgnoreFile)
+                ? ArtifactFilterParser.parse(buildIgnoreFile)
+                : ArtifactFilter.NONE;
+    }
 }


### PR DESCRIPTION
I wanted to check only our updates for our internal dependencies.
Maybe I misunderstood the usage of the `Ignore file`. But I do not want to declare all our 600 dependencies in the ignore-file, just to check updates for our 15 internal ones with the group name prefix `de.companyname`.

This is why I added a `filter` param to **MvnCheck**.
This allows filtering the artifact group by a regular expression.

Here is an example of how to only search for an artifact 
with the group name suffix `com.github.alexisjehan`:
```
- filter com.github.alexisjehan.*
```

I'm happy for any feedback and suggestions.
Maybe it would be good to also add some formatting hints to the project, so I won't destroy the code format with my merge request.